### PR TITLE
Make the .git prefix optional

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -74,7 +74,7 @@ type RepoInfo struct {
 	Name  string
 }
 
-var ownerRepoPattern = regexp.MustCompile(`\/?(.*)\/(.*)\.git$`)
+var ownerRepoPattern = regexp.MustCompile(`\/?(.*)\/([^.]*)(\.git)?$`)
 
 // ExtractRepoInfo TODO
 func ExtractRepoInfo(remote string) (*RepoInfo, error) {

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -19,6 +19,21 @@ func TestExtractHostNameFromRemote(t *testing.T) {
 		}
 	})
 
+	t.Run("ssh string without .git suffix", func(t *testing.T) {
+		url := "git@github.com:golang/go"
+
+		want := RepoInfo{
+			"github.com",
+			"golang",
+			"go",
+		}
+		have, _ := ExtractRepoInfo(url)
+
+		if *have != want {
+			t.Errorf("want: %s; have: %s", want, *have)
+		}
+	})
+
 	t.Run("https string", func(t *testing.T) {
 		url := "https://github.com/golang/go.git"
 


### PR DESCRIPTION
The `.git` is not always required which causes the regex match to fail.