### PR TITLE
Add "set" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # zit
 
-[![](https://api.codacy.com/project/badge/Grade/13955840a985457f8f2e5f22beeea75c)](https://www.codacy.com/manual/ayakovlenko/zit)
-
 _git identity manager_
 
 ## How it works
 
-_zit_ chooses a git identity based on (1) git remote host, (2) repository owner
-name, (3) repository name as defined in a global configuration file
-`$HOME/.zit/config.jsonnet`:
+_zit_ chooses a git identity based on:
+
+1. git remote host
+2. repository owner
+3. repository name
+
+… as defined in the configuration file `$HOME/.zit/config.jsonnet`:
 
 ```jsonnet
 local User(name, email) = { name: name, email: email };
@@ -34,10 +36,10 @@ local user = {
 }
 ```
 
-To set up an identity, run `zit` inside the repo:
+To set up an identity, run `zit set` inside a repo directory:
 
 ```bash
-$ zit  # personal repo
+$ zit set  # personal repo
 set user: jdoe <jdoe@users.noreply.github.com>
 
 $ git remote get-url origin
@@ -45,23 +47,26 @@ https://github.com/jdoe/repo.git
 ```
 
 ```bash
-$ zit  # work repo
+$ zit set  # work repo
 set user: John Doe <john.doe@corp.com>
 
 $ git remote get-url origin
 git@github.corp.com:team/repo.git
 ```
 
+**Note**: Use `--dry-run` flag to test which identity will be used without applying
+it.
+
 ## Installation
 
-On Mac/Linux with Homebrew:
+**On Mac/Linux with Homebrew**
 
 ```bash
 brew tap ayakovlenko/zit
 brew install ayakovlenko/zit/zit
 ```
 
-From sources:
+**From sources**
 
 ```bash
 git clone https://github.com/ayakovlenko/zit.git
@@ -69,7 +74,7 @@ cd zit
 go install
 ```
 
-From binaries:
+**From binaries**
 
 Download binaries from the [releases](https://github.com/ayakovlenko/zit/releases) page.
 

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -1,0 +1,46 @@
+package identity
+
+import (
+	"zit/config"
+	"zit/git"
+)
+
+func findBestMatch(conf config.Config, repo git.RepoInfo) (cred *credentials) {
+	if conf.Default != nil {
+		cred = &credentials{
+			conf.Default.Name,
+			conf.Default.Email,
+		}
+	}
+
+	if conf.Overrides != nil {
+		for _, override := range conf.Overrides {
+			if override.Repo != nil {
+				if override.Owner == repo.Owner && *override.Repo == repo.Name {
+					cred = &credentials{
+						override.User.Name,
+						override.User.Email,
+					}
+					break
+				} else {
+					continue
+				}
+			}
+
+			if override.Owner == repo.Owner {
+				cred = &credentials{
+					override.User.Name,
+					override.User.Email,
+				}
+				break
+			}
+		}
+	}
+
+	return
+}
+
+type credentials struct {
+	name  string
+	email string
+}

--- a/identity/set.go
+++ b/identity/set.go
@@ -1,4 +1,4 @@
-package cred
+package identity
 
 import (
 	"fmt"
@@ -10,10 +10,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// SetCredCmd TODO
-var SetCredCmd = &cobra.Command{
-	Use:   "zit",
-	Short: "git identity manager",
+const dryRunFlag = "dry-run"
+
+// SetCmd is a command that sets git identity based on the configuration file.
+var SetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set git identity",
 	Run: func(cmd *cobra.Command, args []string) {
 		ensureGitDir()
 
@@ -53,55 +55,24 @@ defined in the configuration file:
 			cli.PrintlnExit(fmt.Errorf("cannot find a match for host %q", (*repo).Host))
 		}
 
-		cli.PrintlnExit(
-			git.SetConfig("--local", "user.name", cred.name),
-		)
-		cli.PrintlnExit(
-			git.SetConfig("--local", "user.email", cred.email),
-		)
+		dryRun, err := cmd.Flags().GetBool(dryRunFlag)
+		cli.PrintlnExit(err)
+
+		if !dryRun {
+			cli.PrintlnExit(
+				git.SetConfig("--local", "user.name", cred.name),
+			)
+			cli.PrintlnExit(
+				git.SetConfig("--local", "user.email", cred.email),
+			)
+		}
 
 		fmt.Printf("set user: %s <%s>\n", cred.name, cred.email)
 	},
 }
 
-func findBestMatch(conf config.Config, repo git.RepoInfo) (cred *credentials) {
-	if conf.Default != nil {
-		cred = &credentials{
-			conf.Default.Name,
-			conf.Default.Email,
-		}
-	}
-
-	if conf.Overrides != nil {
-		for _, override := range conf.Overrides {
-			if override.Repo != nil {
-				if override.Owner == repo.Owner && *override.Repo == repo.Name {
-					cred = &credentials{
-						override.User.Name,
-						override.User.Email,
-					}
-					break
-				} else {
-					continue
-				}
-			}
-
-			if override.Owner == repo.Owner {
-				cred = &credentials{
-					override.User.Name,
-					override.User.Email,
-				}
-				break
-			}
-		}
-	}
-
-	return
-}
-
-type credentials struct {
-	name  string
-	email string
+func init() {
+	SetCmd.Flags().Bool(dryRunFlag, false, "dry run")
 }
 
 func ensureGitDir() {

--- a/main.go
+++ b/main.go
@@ -2,17 +2,25 @@ package main
 
 import (
 	"zit/cli"
-	"zit/cred"
 	"zit/doctor"
+	"zit/identity"
 	"zit/version"
+
+	"github.com/spf13/cobra"
 )
 
 func main() {
-	cli.PrintlnExit(cred.SetCredCmd.Execute())
+	cli.PrintlnExit(rootCmd.Execute())
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "zit",
+	Short: "git identity manager",
 }
 
 func init() {
-	cred.SetCredCmd.AddCommand(
+	rootCmd.AddCommand(
+		identity.SetCmd,
 		version.VersionCmd,
 		doctor.DoctorCmd,
 	)

--- a/version/version.go
+++ b/version/version.go
@@ -6,11 +6,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// VersionCmd TODO
+const version = "v2.0.0"
+
+// VersionCmd is a command that prints the app version.
 var VersionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v1.0.4")
+		fmt.Println(version)
 	},
 }


### PR DESCRIPTION
* `zit set` in v2.x behaves like `zit` in v1.x
* `zit set` now has `--dry-run` flag to test which identity will be chosen without applying it
