### PR TITLE
feat: Add support for XDG-style configuration locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,18 @@ hosts:
 
 ## Setup
 
-There are 2 ways to set up a configuration file:
+There are 4 ways to set up a configuration file:
 
-1. Place it at the default location: `$HOME/.zit/config.yaml`
-2. Specify an environment variable that points to the config file:
+1. Specify an environment variable that points to the config file: 
+   ```bash
+   export ZIT_CONFIG=/custom-location/.zit-config.yaml
+   ```
+   If the environment variable is set up, it will be chosen over the configs at the
+default locations.
+2. Place it in [XDG_CONFIG_HOME](https://specifications.freedesktop.org/basedir-spec/0.6/) location: `$XDG_CONFIG_HOME/.zit/config.yaml`
+3. Place it in `.config` location: `$HOME/.config/zit/config.yaml`
+4. Place it at the default location: `$HOME/.zit/config.yaml`
 
-```bash
-export ZIT_CONFIG=/custom-location/.zit-config.yaml
-```
-
-If the environment variable is set up, it will be chosen over the config at the
-default location.
 
 ## Usage
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 
 // EnvVarName TODO
 const EnvVarName = "ZIT_CONFIG"
+const XdgEnvVarName = "XDG_CONFIG_HOME"
 
 // ErrConfigNotFound TODO
 type ErrConfigNotFound struct {
@@ -18,7 +19,7 @@ func (err *ErrConfigNotFound) Error() string {
 	if err.EnvVar {
 		envVar = " defined in " + EnvVarName + " variable"
 	}
-	return fmt.Sprintf("config file%s is not found at %q", envVar, err.Path)
+	return fmt.Sprintf("config file%s is not found at %s", envVar, err.Path)
 }
 
 // HostMap TODO

--- a/internal/identity/set_cmd.go
+++ b/internal/identity/set_cmd.go
@@ -33,17 +33,19 @@ var SetCmd = &cli.Command{
 		if err != nil {
 			return fmt.Errorf("cannot user home dir: %v", err)
 		}
-
-		configPathFromEnv := os.Getenv(config.EnvVarName)
-
+		
 		if err := gitutil.EnsureGitDir(gitClient); err != nil {
 			return err
 		}
+
+		configPathFromEnv := os.Getenv(config.EnvVarName)
+		xdgHomePathFromEnv := os.Getenv(config.XdgEnvVarName)
 
 		confPath, err := config.LocateConfFile(
 			fs,
 			userHomeDir,
 			configPathFromEnv,
+			xdgHomePathFromEnv,
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
This commit introduces support for the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/), enabling users to store configuration files in standard XDG directories. Configuration can now be accessed from:

- `$ZIT_CONFIG`
- Fallback to `$XDG_CONFIG_HOME` (default: `~/.config/zit`) if `$ZIT_CONFIG` is not set.
- Fallback to `$HOME/.zit` if `XDG_CONFIG_HOME` is not set.

This enhancement aligns with modern practices for managing application settings, improving the overall user experience.