### PR TITLE
fix: more helpful message when remote is not set

### DIFF
--- a/internal/app/appconfig.go
+++ b/internal/app/appconfig.go
@@ -14,7 +14,7 @@ type Config interface {
 
 const (
 	appName        = "zit"
-	appVersion     = "v3.1.1"
+	appVersion     = "v3.1.2"
 	configFilename = "config.yaml"
 )
 

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -3,7 +3,6 @@ package gitutil
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"zit/pkg/git"
 
@@ -19,13 +18,24 @@ func (e *ErrNoRemoteURL) Error() string {
 	return fmt.Sprintf("remote %q is not set", e.name)
 }
 
+// exitCoder matches exec.ExitError and our mock
+type exitCoder interface {
+	ExitCode() int
+}
+
 // RemoteURL gets git remote URL by remote name.
 func RemoteURL(gitClient git.GitClient, name string) (string, error) {
 	out, err := gitClient.Exec("remote", "get-url", name)
 	if err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			if exitError.ExitCode() == 128 {
+		if exitError, ok := err.(exitCoder); ok {
+			// Exit code 2: remote name is invalid or not set
+			if exitError.ExitCode() == 2 {
 				return "", &ErrNoRemoteURL{name}
+			}
+
+			// Exit code 128: not a git repository or other fatal git errors
+			if exitError.ExitCode() == 128 {
+				return "", fmt.Errorf("%s", out)
 			}
 		}
 		return out, err
@@ -39,7 +49,7 @@ func GetConfig(gitClient git.GitClient, scope, key string) (string, error) {
 	out, err := gitClient.Exec("config", scope, key)
 
 	if err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
+		if exitError, ok := err.(exitCoder); ok {
 			if exitError.ExitCode() == 1 {
 				return "", nil
 			}
@@ -119,6 +129,10 @@ If you are, perhaps you have forgotten to initialize a new repository? In this
 case, run:
 
     git init
+
+Or, if you have an existing repository but haven't set up the remote URL:
+
+    git remote add origin <url>
 `, dir)
 		os.Exit(1)
 	}

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -1,7 +1,10 @@
 package gitutil
 
 import (
+	"errors"
 	"testing"
+
+	"zit/pkg/git"
 )
 
 func TestExtractHostNameFromRemote(t *testing.T) {
@@ -106,5 +109,61 @@ func TestExtractHostNameFromRemote(t *testing.T) {
 
 			assertEquals(t, have, want)
 		})
+	})
+}
+
+func TestRemoteURL(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		gitClient := git.NewMockGitClient()
+		gitClient.AddCommand(
+			[]string{"remote", "get-url", "origin"},
+			"git@github.com:user/repo.git",
+			nil,
+		)
+
+		url, err := RemoteURL(gitClient, "origin")
+
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if url != "git@github.com:user/repo.git" {
+			t.Errorf("want: git@github.com:user/repo.git; have: %s", url)
+		}
+	})
+
+	t.Run("exit code 2: remote not set", func(t *testing.T) {
+		gitClient := git.NewMockGitClient()
+		gitClient.AddExitError(
+			[]string{"remote", "get-url", "origin"},
+			"error: No such remote 'origin'",
+			2,
+		)
+
+		_, err := RemoteURL(gitClient, "origin")
+
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if !errors.Is(err, &ErrNoRemoteURL{"origin"}) && err.Error() != `remote "origin" is not set` {
+			t.Errorf("expected ErrNoRemoteURL, got: %v", err)
+		}
+	})
+
+	t.Run("exit code 128: return underlying error", func(t *testing.T) {
+		gitClient := git.NewMockGitClient()
+		gitClient.AddExitError(
+			[]string{"remote", "get-url", "origin"},
+			"fatal: not a git repository",
+			128,
+		)
+
+		_, err := RemoteURL(gitClient, "origin")
+
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if err.Error() != "fatal: not a git repository" {
+			t.Errorf("expected git error message, got: %v", err)
+		}
 	})
 }

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -2,9 +2,18 @@ package git
 
 import "fmt"
 
+// exitCoder matches exec.ExitError and our mock
+type exitCoder interface {
+	ExitCode() int
+}
+
 func IsGitDir(client GitClient) (bool, error) {
 	out, err := client.Exec("rev-parse", "--is-inside-work-tree")
 	if err != nil {
+		// Exit code 128 means not a git repository: treat as "false"
+		if exitErr, ok := err.(exitCoder); ok && exitErr.ExitCode() == 128 {
+			return false, nil
+		}
 		return false, err
 	}
 	return out == "true", nil

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -16,22 +16,54 @@ func TestIsGitDir(t *testing.T) {
 			nil,
 		)
 
-		ok, _ := IsGitDir(gitClient)
+		ok, err := IsGitDir(gitClient)
 
+		assert.NoError(t, err)
 		assert.True(t, ok)
 	})
 
-	t.Run("is not git directory", func(t *testing.T) {
+	t.Run("output is false", func(t *testing.T) {
 		gitClient := NewMockGitClient()
 
 		gitClient.AddCommand(
 			[]string{"rev-parse", "--is-inside-work-tree"},
-			"fatal: not a git repository (or any of the parent directories): .git",
+			"false",
 			nil,
 		)
 
-		ok, _ := IsGitDir(gitClient)
+		ok, err := IsGitDir(gitClient)
 
+		assert.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("exit code 128: not a git repository", func(t *testing.T) {
+		gitClient := NewMockGitClient()
+
+		gitClient.AddExitError(
+			[]string{"rev-parse", "--is-inside-work-tree"},
+			"fatal: not a git repository (or any of the parent directories): .git",
+			128,
+		)
+
+		ok, err := IsGitDir(gitClient)
+
+		assert.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("other exit codes: return error", func(t *testing.T) {
+		gitClient := NewMockGitClient()
+
+		gitClient.AddExitError(
+			[]string{"rev-parse", "--is-inside-work-tree"},
+			"some other error",
+			1,
+		)
+
+		ok, err := IsGitDir(gitClient)
+
+		assert.Error(t, err)
 		assert.False(t, ok)
 	})
 }

--- a/pkg/git/mock_client.go
+++ b/pkg/git/mock_client.go
@@ -6,36 +6,55 @@ import (
 )
 
 type mockGitClient struct {
-	commands map[string][2]interface{}
+	commands map[string]mockResult
+}
+
+type mockResult struct {
+	output string
+	err    error
 }
 
 func NewMockGitClient() *mockGitClient {
 	return &mockGitClient{
-		commands: make(map[string][2]interface{}),
+		commands: make(map[string]mockResult),
 	}
 }
 
 func (m *mockGitClient) Exec(args ...string) (string, error) {
 	cmd := strings.Join(args, " ")
 
-	if tup, ok := m.commands[cmd]; ok {
-		var ret string = tup[0].(string)
-		var err error
-
-		if isNil := tup[1] == nil; !isNil {
-			err = tup[1].(error)
-		}
-
-		return ret, err
+	if res, ok := m.commands[cmd]; ok {
+		return res.output, res.err
 	}
 
 	return "", fmt.Errorf("command %q not found in mock", cmd)
 }
 
-func (m *mockGitClient) AddCommand(args []string, ret string, err error) {
+func (m *mockGitClient) AddCommand(args []string, output string, err error) {
 	argsKey := strings.Join(args, " ")
-	m.commands[argsKey] = [2]interface{}{
-		ret,
-		err,
+	m.commands[argsKey] = mockResult{
+		output: output,
+		err:    err,
 	}
+}
+
+func (m *mockGitClient) AddExitError(args []string, output string, exitCode int) {
+	argsKey := strings.Join(args, " ")
+	m.commands[argsKey] = mockResult{
+		output: output,
+		err:    &mockExitError{exitCode: exitCode, stderr: output},
+	}
+}
+
+type mockExitError struct {
+	exitCode int
+	stderr   string
+}
+
+func (e *mockExitError) Error() string {
+	return fmt.Sprintf("exit status %d", e.exitCode)
+}
+
+func (e *mockExitError) ExitCode() int {
+	return e.exitCode
 }


### PR DESCRIPTION
Handle different git exit codes properly:

- Exit code 2: remote not set -> show helpful message about adding remote
- Exit code 128: not a git repo -> show "not a git directory" message
- Other exit codes: propagate underlying error

Fixes #28